### PR TITLE
Add PR naming guidelines

### DIFF
--- a/Git.md
+++ b/Git.md
@@ -28,6 +28,7 @@ Follow these [guidelines](http://chris.beams.io/posts/git-commit/#seven-rules):
 - Use the body to explain what and why vs. how
 
 ## Pull Requests
+- PR titles and bodies should adhere to the same guidelines outlined above for commits.
 - The PR submitter is responsible for handling any reviewer requested changes. This only changes
   in the following scenarios:
   - The submitter requests assistance from a coworker and passes responsibility.


### PR DESCRIPTION
We currently have Pull Request titles like... 
- `Feature/did something`
- `Bug/add fix for this`
- `WIP throw away branch`
- `a lower case sentence is great`
- `i am really fond of punctuation!!`

I'd like to propose that our PR's should follow the same format as our commit messages (e.g. – capitalized, imperative mood, no period, etc).

P.S. – One great feature of GitHub PR's is that if your PR has a single commit (i.e. – you rebase and squash your commits), then GitHub will auto-populate the title/body with your commit title/body. This is another reason why I like/recommend squashing branches into a single commit.
