### PR TITLE
Moves ui above template since it is a view property

### DIFF
--- a/JavaScript.md
+++ b/JavaScript.md
@@ -125,14 +125,15 @@ Much of this was inspired by [idiomatic-js](https://github.com/necolas/idiomatic
   # good
   Marionette.CollectionVew.extend
     className: 'view-edit-classroom'
-    template: tpl
-
-    itemView: itemView
-    itemViewContainer: '#js-itemview-container'
 
     ui:
       backBtn: '#js-back'
       submitBtn: '#js-submit'
+
+    template: tpl
+
+    itemView: itemView
+    itemViewContainer: '#js-itemview-container'
 
     initialize: ->
 

--- a/JavaScript.md
+++ b/JavaScript.md
@@ -125,12 +125,11 @@ Much of this was inspired by [idiomatic-js](https://github.com/necolas/idiomatic
   # good
   Marionette.CollectionVew.extend
     className: 'view-edit-classroom'
+    template: tpl
 
     ui:
       backBtn: '#js-back'
       submitBtn: '#js-submit'
-
-    template: tpl
 
     itemView: itemView
     itemViewContainer: '#js-itemview-container'


### PR DESCRIPTION
This PR updates the styleguide to place the `ui` declaration above `template` for a MarionetteView since it is a view property.
